### PR TITLE
Remove carpet visual gaps for seamless board appearance

### DIFF
--- a/marrakesh/client/components/game/Board.tsx
+++ b/marrakesh/client/components/game/Board.tsx
@@ -93,7 +93,7 @@ export function Board({
               >
                 {color ? (
                   <div
-                    className="absolute inset-0 m-[2px] rounded-sm opacity-90"
+                    className="absolute inset-0 opacity-90"
                     style={{
                       backgroundColor: color,
                       backgroundImage: texture ? `url(${texture})` : undefined,


### PR DESCRIPTION
## Purpose
The user requested to make carpets appear visually seamless without gaps between them, while ensuring they align properly with the board's grid cells. The goal was to create a continuous, unified visual appearance for carpets on the game board.

## Code changes
- Removed `m-[2px]` and `rounded-sm` classes from carpet div elements in Board.tsx
- This eliminates the 2px margin that was creating visual gaps between adjacent carpet pieces
- Carpets now fill the entire cell area without spacing, creating a seamless appearance when placed next to each other

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7558c3e1302a4deda81da506ea3e07fa/zen-works)

👀 [Preview Link](https://7558c3e1302a4deda81da506ea3e07fa-zen-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7558c3e1302a4deda81da506ea3e07fa</projectId>-->
<!--<branchName>zen-works</branchName>-->